### PR TITLE
Fix dark mode label color

### DIFF
--- a/static/sprint-goal.html
+++ b/static/sprint-goal.html
@@ -96,7 +96,7 @@
             color: #a65d00;    
             padding: 10px;
             margin: 10px 0px 10px 0px;
-            text-align: center
+            text-align: center;
             border-radius: 4px;
             display: none;
         }

--- a/static/sprint-goal.html
+++ b/static/sprint-goal.html
@@ -93,9 +93,10 @@
         #ditwerkniettooltip {
             border: 1px solid #f4ce42;
             background-color: #fff2c4;
+            color: #a65d00;    
             padding: 10px;
             margin: 10px 0px 10px 0px;
-            text-align: center;
+            text-align: center
             border-radius: 4px;
             display: none;
         }


### PR DESCRIPTION
Adjusted label color for #ditwerkniettooltip so it is properly visible in dark and light mode.